### PR TITLE
add and visulalize 2D metaballs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # MetaBalls
+
+This package provides a simple implementation of 2D [metaballs](https://en.wikipedia.org/wiki/Metaballs).
+
+Here is an example:
+
+<img src="https://user-images.githubusercontent.com/32610387/123609441-48163c00-d81d-11eb-8d70-4d5a2239a1b2.png">

--- a/src/MetaBalls.jl
+++ b/src/MetaBalls.jl
@@ -1,5 +1,6 @@
 module MetaBalls
 
-# Write your package code here.
+include("metaball.jl")
+include("visualize.jl")
 
 end

--- a/src/metaball.jl
+++ b/src/metaball.jl
@@ -1,0 +1,18 @@
+struct MetaBall{T}
+    i_center::T
+    j_center::T
+    radius::T
+end
+
+function generate_field!(field::AbstractMatrix, metaballs::Array{MetaBall{T}, 1}) where {T}
+    height, width = size(field)
+    for j in 1:width
+        for i in 1:height
+            for metaball in metaballs
+                field[i, j] += (metaball.radius ^ 2) / ((i - metaball.i_center) ^ 2 + (j - metaball.j_center) ^ 2)
+            end
+        end
+    end
+
+    return nothing
+end

--- a/src/visualize.jl
+++ b/src/visualize.jl
@@ -1,0 +1,21 @@
+function visualize(io::IO, image::AbstractMatrix{Bool})
+    height, width = size(image)
+    for i in 1:height
+        for j in 1:width
+            if image[i, j]
+                print(io, "██")
+            else
+                if iseven(i + j)
+                    print(io, "░░")
+                else
+                    print(io, "▒▒")
+                end
+            end
+        end
+        println(io)
+    end
+
+    return nothing
+end
+
+visualize(image::AbstractMatrix) = visualize(stdout, image)


### PR DESCRIPTION
1. Add type `MetaBall` that represents the center and radius of a 2D metaball. Add method `generate_field!` that generates the total influence of a collection of metaballs for all the points on a 2D grid.
2. Add method `visualize` to visualize a bitmap inside the terminal.
3. Update README with basic info.